### PR TITLE
Add TTL field to multi upsert request

### DIFF
--- a/idl/dosa/dosa.thrift
+++ b/idl/dosa/dosa.thrift
@@ -151,6 +151,7 @@ struct UpsertRequest {
 struct MultiUpsertRequest {
     1: optional SchemaRef ref
     2: optional list<FieldValueMap> entities
+    3: optional i64 ttl
 }
 
 struct RemoveRequest {


### PR DESCRIPTION
This adds an optional TTL field for the multi upsert request.